### PR TITLE
fix: add GitHub Actions workflows for scheduled publishing and testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,13 +24,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install -g turbo orval jest prettier
-          npm install
+          pnpm install -g turbo orval jest prettier
+          pnpm install
 
       - name: Run tests
         run: |
-          npm run test
+          pnpm run test
 
       - name: Build package
         run: |
-          npm run build
+          pnpm run build


### PR DESCRIPTION
This pull request updates the CI workflow to use `pnpm` instead of `npm` for dependency management, testing, and building.

Key changes:

* [`.github/workflows/testing.yml`](diffhunk://#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL27-R36): Replaced `npm` commands with `pnpm` equivalents for installing global dependencies, installing project dependencies, running tests, and building the package.